### PR TITLE
Upgrading 1Password CLI to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Here is an unofficial Dockerfile for the [1Password command-line tool][ophomepage].
 
-It is available on [docker hub][dockerhubpage] based on [Debian][debianhubpage] and using the last available release from the official [1Password CLI download page][opdlpage].
+It is available on [docker hub][dockerhubpage] based on [Debian][debianhubpage] and [Alpine][alpinehubpage] using the last available release from the official [1Password CLI download page][opdlpage].
 
 ## Changelog
 
+- 2022-03-30 Upgrading 1Password CLI to 2.0.0
 - 2020-04-01 Upgrading 1Password CLI to 0.9.4
 - 2020-04-01 Upgrading 1Password CLI to 0.9.3
 - 2020-02-29 Upgrading 1Password CLI to 0.9.2
@@ -38,8 +39,8 @@ Add this line to you `.bashrc`:
 
 then just run `op` like you would with a standard install (without docker) from a new bash session.
 
-  [ophomepage]: https://support.1password.com/command-line-getting-started "1Password command-line tool"
-  [opdlpage]: https://app-updates.agilebits.com/product_history/CLI "1Password CLI downloads"
+  [ophomepage]: https://developer.1password.com/docs/cli/get-started "1Password command-line tool"
+  [opdlpage]: https://app-updates.agilebits.com/product_history/CLI2 "1Password CLI downloads"
   [dockerhubpage]: https://hub.docker.com/r/tophfr/op "1Password CLI (op) hub page"
   [debianhubpage]: https://hub.docker.com/_/debian "Docker Official Images hub page"
-
+  [alpinehubpage]: https://hub.docker.com/_/alpine "Docker Official Images hub page"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.11
+FROM alpine:3.15
 
-ENV OP_VERSION 0.9.4
+ENV OP_VERSION 2.0.0
 RUN apk add --no-cache ca-certificates \
     && apk add --no-cache --virtual .build-deps gnupg \
     && cd /root \
-    && wget -O op.zip https://cache.agilebits.com/dist/1P/op/pkg/v$OP_VERSION/op_linux_386_v$OP_VERSION.zip \
+    && wget -O op.zip https://cache.agilebits.com/dist/1P/op2/pkg/v$OP_VERSION/op_linux_arm64_v$OP_VERSION.zip \
     && unzip op.zip \
     && gpg --receive-keys 3FEF9748469ADBE15DA7CA80AC2D62742012EA22 \
     && gpg --verify op.sig op \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,12 @@
 FROM debian:buster-slim
 
-ENV OP_VERSION 0.9.4
+ENV OP_VERSION 2.0.0
 RUN buildDeps="curl gnupg dirmngr unzip" \
     && runDeps="ca-certificates" \
     && apt-get update \
     && apt-get install -y --no-install-recommends $runDeps $buildDeps \
     && cd /root \
-    && curl -sSL -o op.zip https://cache.agilebits.com/dist/1P/op/pkg/v$OP_VERSION/op_linux_amd64_v$OP_VERSION.zip \
+    && curl -sSL -o op.zip https://cache.agilebits.com/dist/1P/op2/pkg/v$OP_VERSION/op_linux_$(dpkg --print-architecture)_v$OP_VERSION.zip \
     && unzip op.zip \
     && gpg --keyserver hkp://keyserver.ubuntu.com --receive-keys 3FEF9748469ADBE15DA7CA80AC2D62742012EA22 \
     && gpg --verify op.sig op \


### PR DESCRIPTION
Debian is the `:latest` default and should be ok for multi-architecture builds. Alpine isn't, so I hardcoded it to what an M1 apple cpu uses, even though `arch` and `uname -m` say "aarch64" in alpine.